### PR TITLE
Fix packet length validation

### DIFF
--- a/msp-secure.py
+++ b/msp-secure.py
@@ -94,8 +94,12 @@ def parse_packet(data, msp_secure=None):
     """Parse MSP packet with optional decryption"""
     if data[:2] != SYNC:
         return None, 'Invalid SYNC'
-    
+    if len(data) < 7:
+        return None, 'Packet too short'
+
     total_length = struct.unpack('!H', data[2:4])[0]
+    if len(data) != total_length:
+        return None, 'Invalid length'
     version, packet_type = data[4], data[5]
     payload_bytes = data[6:-1]
     crc = data[-1]

--- a/msp.py
+++ b/msp.py
@@ -17,7 +17,11 @@ def build_packet(packet_type, payload):
 def parse_packet(data):
     if data[:2] != SYNC:
         return None, 'Invalid SYNC'
+    if len(data) < 7:
+        return None, 'Packet too short'
     total_length = struct.unpack('!H', data[2:4])[0]
+    if len(data) != total_length:
+        return None, 'Invalid length'
     version, packet_type = data[4], data[5]
     payload = data[6:-1]
     crc = data[-1]


### PR DESCRIPTION
## Summary
- validate packet length for MSP
- validate packet length for secure MSP

## Testing
- `python -m py_compile msp.py msp-secure.py`
- `python msp.py --mode client --host 127.0.0.1 --port 9009 --message "Hello MSP"` (server ran separately)

------
https://chatgpt.com/codex/tasks/task_e_68453ebb4af0832ea913f3f60c70731f